### PR TITLE
Harden requests against SSRF via redirect controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ This tap:
  
     - `organization`, your Selligent organization name (looks like "Organization")
     - `api_key`, your API Key
-    - `base_url`, the base URL of your Selligent installation (looks like "https://organization.yourhost.com:443")
+        - `base_url`, the base URL of your Selligent installation (looks like "https://organization.yourhost.com:443")
+            - Redirects are only followed within the same origin and up to `max_redirects` hops.
+        - `max_redirects`, optional integer redirect limit (default `3`). Set to `0` to disable redirect following.
     - `user_agent`, the user-agent to set as a header on all requests made. Include your email address. (example: "tap-selligent (you@yourdomain.com)")
     - `start_date`, the date from which you want to sync data, in the format `2017-03-10`.
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,8 @@
 {
     "organization": "",
-    "api_key": ""
+    "api_key": "",
     "base_url": "",
+    "max_redirects": 3,
     "start_date": "",
     "user_agent": ""
 }

--- a/tap_selligent/__init__.py
+++ b/tap_selligent/__init__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+from urllib.parse import urljoin, urlparse
 
 import requests
 import singer
@@ -12,32 +13,85 @@ import tap_selligent.schemas
 logger = singer.get_logger()
 
 BASE_URL = 'https://backstage.taboola.com'
+DEFAULT_MAX_REDIRECTS = 3
+
+
+def is_same_origin(source_url, target_url):
+    source = urlparse(source_url)
+    target = urlparse(target_url)
+
+    return (source.scheme, source.hostname, source.port) == \
+        (target.scheme, target.hostname, target.port)
 
 
 def request(url, config, params={}):
     user_agent = config['user_agent']
     api_key = config['api_key']
     organization = config['organization']
-
-    logger.info("Making request: GET {} {}".format(url, params))
+    max_redirects = config.get('max_redirects', DEFAULT_MAX_REDIRECTS)
 
     try:
-        response = requests.get(
-            url,
-            headers={'Authorization': api_key,
-                     'X-Organization': organization,
-                     'Accept': 'application/json',
-                     'User-Agent': user_agent},
-            params=params)
+        max_redirects = int(max_redirects)
+    except (TypeError, ValueError):
+        logger.fatal("Config value max_redirects must be an integer")
+        raise RuntimeError
 
-    except BaseException as e:
-        logger.exception(e)
-        raise e
+    if max_redirects < 0:
+        logger.fatal("Config value max_redirects must be >= 0")
+        raise RuntimeError
 
-    logger.info("Got response code: {}".format(response.status_code))
+    request_url = url
+    request_params = params
+    redirect_count = 0
 
-    response.raise_for_status()
-    return response
+    while True:
+        logger.info("Making request: GET {} {}".format(request_url, request_params))
+
+        try:
+            response = requests.get(
+                request_url,
+                headers={'Authorization': api_key,
+                         'X-Organization': organization,
+                         'Accept': 'application/json',
+                         'User-Agent': user_agent},
+                params=request_params,
+                allow_redirects=False)
+
+        except BaseException as e:
+            logger.exception(e)
+            raise e
+
+        logger.info("Got response code: {}".format(response.status_code))
+
+        if response.is_redirect:
+            redirect_target = response.headers.get('Location', '')
+            redirected_url = urljoin(request_url, redirect_target)
+
+            if not redirect_target:
+                logger.fatal("Blocked redirect response without Location header for URL {}"
+                             .format(request_url))
+                raise RuntimeError
+
+            if not is_same_origin(url, redirected_url):
+                logger.fatal("Blocked cross-origin redirect response for URL {} to {}"
+                             .format(request_url, redirected_url))
+                raise RuntimeError
+
+            if redirect_count >= max_redirects:
+                logger.fatal("Blocked redirect chain after {} redirects for URL {}"
+                             .format(redirect_count, url))
+                raise RuntimeError
+
+            redirect_count += 1
+            logger.info("Following redirect {} of {}: {}"
+                        .format(redirect_count, max_redirects, redirected_url))
+
+            request_url = redirected_url
+            request_params = {}
+            continue
+
+        response.raise_for_status()
+        return response
 
 
 def fetch_transactional_mailings(config, state):

--- a/tests/test_request_security.py
+++ b/tests/test_request_security.py
@@ -1,0 +1,106 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import tap_selligent
+
+
+class RequestSecurityTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            'user_agent': 'tap-selligent (security@test.local)',
+            'api_key': 'test-api-key',
+            'organization': 'test-org'
+        }
+        self.url = 'https://example.selligent.test/sm/rest/v1/programs/'
+
+    @patch('tap_selligent.requests.get')
+    def test_request_disables_redirect_following(self, get_mock):
+        response = Mock()
+        response.status_code = 200
+        response.is_redirect = False
+        response.raise_for_status = Mock()
+        get_mock.return_value = response
+
+        tap_selligent.request(self.url, self.config, {})
+
+        _, kwargs = get_mock.call_args
+        self.assertFalse(kwargs['allow_redirects'])
+        response.raise_for_status.assert_called_once_with()
+
+    @patch('tap_selligent.logger.fatal')
+    @patch('tap_selligent.requests.get')
+    def test_request_blocks_redirect_responses(self, get_mock, logger_fatal_mock):
+        response = Mock()
+        response.status_code = 302
+        response.is_redirect = True
+        response.headers = {
+            'Location': 'http://169.254.169.254/latest/meta-data/iam/security-credentials/'
+        }
+        response.raise_for_status = Mock()
+        get_mock.return_value = response
+
+        with self.assertRaises(RuntimeError):
+            tap_selligent.request(self.url, self.config, {})
+
+        response.raise_for_status.assert_not_called()
+        logger_fatal_mock.assert_called_once()
+
+    @patch('tap_selligent.requests.get')
+    def test_request_follows_same_origin_redirect_with_limit(self, get_mock):
+        redirect_response = Mock()
+        redirect_response.status_code = 302
+        redirect_response.is_redirect = True
+        redirect_response.headers = {
+            'Location': '/sm/rest/v1/programs/?page=1'
+        }
+        redirect_response.raise_for_status = Mock()
+
+        ok_response = Mock()
+        ok_response.status_code = 200
+        ok_response.is_redirect = False
+        ok_response.headers = {}
+        ok_response.raise_for_status = Mock()
+
+        get_mock.side_effect = [redirect_response, ok_response]
+
+        config = dict(self.config)
+        config['max_redirects'] = 1
+
+        result = tap_selligent.request(self.url, config, {'limit': 10000})
+
+        self.assertEqual(result, ok_response)
+        self.assertEqual(get_mock.call_count, 2)
+
+    @patch('tap_selligent.logger.fatal')
+    @patch('tap_selligent.requests.get')
+    def test_request_blocks_excessive_redirect_chain(self, get_mock, logger_fatal_mock):
+        redirect_response_1 = Mock()
+        redirect_response_1.status_code = 302
+        redirect_response_1.is_redirect = True
+        redirect_response_1.headers = {
+            'Location': '/sm/rest/v1/programs/?page=1'
+        }
+        redirect_response_1.raise_for_status = Mock()
+
+        redirect_response_2 = Mock()
+        redirect_response_2.status_code = 302
+        redirect_response_2.is_redirect = True
+        redirect_response_2.headers = {
+            'Location': '/sm/rest/v1/programs/?page=2'
+        }
+        redirect_response_2.raise_for_status = Mock()
+
+        get_mock.side_effect = [redirect_response_1, redirect_response_2]
+
+        config = dict(self.config)
+        config['max_redirects'] = 1
+
+        with self.assertRaises(RuntimeError):
+            tap_selligent.request(self.url, config, {})
+
+        self.assertEqual(get_mock.call_count, 2)
+        logger_fatal_mock.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description of change
Bugcrowd have reported an SSRF issue in the selligent connector that I’ve reproduced. The Selligent connector uses Python's requests library, which follows HTTP 302 redirects by default. By pointing base_url at an attacker-controlled redirect server, we can make the extraction worker issue HTTP GET requests to the AWS metadata endpoint.

We should update it so that either it doesn’t follow re-directs, or else forbids redirecting to an internal IP (e.g. link local). Also we should limit the number of redirections, I noticed it would redirect a ton of times.

Set Redirects to False and also number of redirects are restricted to 3

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
